### PR TITLE
set skk-jisyo-code

### DIFF
--- a/init.d/skk-init.el
+++ b/init.d/skk-init.el
@@ -4,6 +4,7 @@
 
 (setq skk-cdb-large-jisyo nil)
 (setq skk-large-jisyo (concat external-directory "ddskk/SKK-JISYO.L"))
+(setq skk-jisyo-code 'euc-jis-2004-unix)
 
 (dolist (JISYO
 	 (list "assoc" "edict" "fullname" "geo" "itaiji" "jinmei"


### PR DESCRIPTION
- Windows 環境で改行コードが CRLF になってしまうので、euc-jis-2004-unix
  を明示的に指定する