### PR TITLE
feat(emacs): add additional package archives and dependencies

### DIFF
--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -189,7 +189,7 @@
                      "ae2202fbbbe11873ad4b393a6959da50ac250c1e")
         (helm :checksum "4e99cc8ef66aac2d824c456f58abe833be26c99d")
         (howm :checksum "00fb080ccc7d6929a6ee9bb480484c9308727d09")
-        (magit :checksum "bf58615a033b8c827bf630962531c67539789215")
+        (magit :checksum "dc0094bd88a5307fdfa1c2a48f3ec5b33891f1f0")
         (transient :checksum
                    "afc88b24e4faa5c7e246303648e70b4507652f32")
         (smart-jump :checksum

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -49,6 +49,10 @@
 ;; installed packages.  Don't delete this line.  If you don't want it,
 ;; just comment it out by adding a semicolon to the start of the line.
 ;; You may delete these explanatory comments.
+(require 'package)
+(add-to-list 'package-archives '("gnu" . "https://elpa.gnu.org/packages/"))
+(add-to-list 'package-archives '("nongnu" . "https://elpa.nongnu.org/nongnu/"))
+(add-to-list 'package-archives '("melpa" . "https://melpa.org/packages/"))
 (package-initialize)
 
 (when load-file-name
@@ -576,10 +580,11 @@
   :branch "main")
 (el-get-bundle with-editor
   :branch "main")
+(el-get-bundle elpa:cond-let)
 (el-get-bundle magit
   :type github
   :pkgname "magit/magit"
-  :depends (transient with-editor compat)
+  :depends (transient with-editor compat cond-let)
   :load-path "lisp/"
   :compile "lisp/"
   :build `(("make" ,(format "EMACSBIN=%s" el-get-emacs) "lisp")


### PR DESCRIPTION
Added GNU, NonGNU, and MELPA package archives to the configuration. Updated `magit` dependencies to include `cond-let`.