### PR TITLE
chore: update dependencies and development environment configuration

### DIFF
--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,15 @@
 (setq el-get-lock-package-versions
-      '((poly-markdown :checksum
+      '((eat :checksum "c8d54d649872bfe7b2b9f49ae5c2addbf12d3b99")
+        (vterm :checksum "056ad74653704bc353d8ec8ab52ac75267b7d373")
+        (web-server :checksum
+                    "6357a1c2d1718778503f7ee0909585094117525b")
+        (websocket :checksum
+                   "40c208eaab99999d7c1e4bea883648da24c03be3")
+        (claude-code-ide :checksum
+                         "853440e3d8cebfef49ba9da5e2991422b8c778f4")
+        (pyvenv.el :checksum
+                   "31ea715f2164dd611e7fc77b26390ef3ca93509b")
+        (poly-markdown :checksum
                        "98695eb7ca4ca11dcec71a1cab64903bbf79b4d3")
         (polymode :checksum "74ba75d4bcfbea959ccc9080a95ab9ef759849f2")
         (emacs-fsharp-mode :checksum
@@ -46,7 +56,7 @@
                        "1c5b2254dd72f2ff504d6a6189a8c10be03a98d1")
         (compat :checksum "bfc0a46098be2dcaad0518ec200ff5a2be5cc9bb")
         (lsp-bridge :checksum
-                    "cecb939f40ebde5c82d888a532c0494969997b4a")
+                    "3b37a04bd1b6bbcdc2b0ad7a5c388ad027eb7a25")
         (copilot :checksum "8a0068afcfb98af7f172d04f6f8cc932c1a22fe8")
         (eldoc-box :checksum
                    "5c067f5c195198ffd16df2f455da95e46cc8ce02")
@@ -93,7 +103,7 @@
         (tree-mode :checksum
                    "b06078826d5875d74b0e7b7ac47b0d0917610534")
         (with-editor :checksum
-                     "ca902ae02972bdd6919a902be2593d8cb6bd991b")
+                     "87a384a0e59260cca41ca8831d98e195b1ec8ada")
         (terminal-here :checksum
                        "d321d9e33e42cba045341b0ef4d978056ad6f4d7")
         (emacs-sql-indent :checksum
@@ -120,7 +130,7 @@
         (popwin :checksum "0d5788074a9df6a7a0285be58cfc3a5a545bb5c4")
         (twittering-mode :checksum
                          "114891e8fdb4f06b1326a6cf795e49c205cf9e29")
-        (mew :checksum "c46d8ee784d098244abaf162660073d1d4787b60")
+        (mew :checksum "2392ee9b869029a9900587011fe541abe08a2fd5")
         (dockerfile-mode :checksum
                          "4d893bd2da15833ce056332e6c972d5d93e78f04")
         (lsp-haskell :checksum
@@ -189,9 +199,9 @@
                      "ae2202fbbbe11873ad4b393a6959da50ac250c1e")
         (helm :checksum "4e99cc8ef66aac2d824c456f58abe833be26c99d")
         (howm :checksum "00fb080ccc7d6929a6ee9bb480484c9308727d09")
-        (magit :checksum "dc0094bd88a5307fdfa1c2a48f3ec5b33891f1f0")
+        (magit :checksum "b828afbb4b45641998fb6483a08effb1efb214e1")
         (transient :checksum
-                   "afc88b24e4faa5c7e246303648e70b4507652f32")
+                   "053d56e4de2dd78bf32f7af7ed5f289a91cdb6ac")
         (smart-jump :checksum
                     "3392eb35e3cde37e6f5f2a48dc0db15ca535143c")
         (dumb-jump :checksum

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -131,7 +131,8 @@
                    (expand-file-name "~/bin")
                    (expand-file-name "~/.emacs.d/bin")
                    (expand-file-name "~/.emacs.d/el-get/mew/bin")
-                   (expand-file-name "~/.local/bin")))
+                   (expand-file-name "~/.local/bin")
+                   (expand-file-name "~/.config/claude/local/")))
 
   (when (and (file-exists-p dir) (not (member dir exec-path)))
     (setenv "PATH" (concat dir ":" (getenv "PATH")))

--- a/.zsh/.zcompctl
+++ b/.zsh/.zcompctl
@@ -17,5 +17,9 @@ autoload -U +X bashcompinit && bashcompinit
 autoload -Uz compinit && compinit
 complete -o nospace -C /usr/bin/terraform terraform
 
+if [ -f "$HOME/.config/azure-cli-env/az.completion" ]; then
+  source "$HOME/.config/azure-cli-env/az.completion"
+fi
+
 zstyle ':completion:*:default' menu select=1
 zstyle ':completion:*' matcher-list 'm:{a-z}={A-Z}'

--- a/.zsh/.zshrc
+++ b/.zsh/.zshrc
@@ -86,3 +86,9 @@ fi
 
 # To customize prompt, run `p10k configure` or edit ~/dotfiles/.zsh/.p10k.zsh.
 [[ ! -f ${XDG_CONFIG_HOME}/dotfiles/.zsh/.p10k.zsh ]] || source ${XDG_CONFIG_HOME}/dotfiles/.zsh/.p10k.zsh
+
+. "$HOME/.local/share/../bin/env"
+
+# bun completions
+[ -s "/home/nanasess/.bun/_bun" ] && source "/home/nanasess/.bun/_bun"
+

--- a/.zsh/.zshrc.mine
+++ b/.zsh/.zshrc.mine
@@ -41,6 +41,10 @@ export PATH=/usr/local/sbin:$PATH
 export PATH="/mnt/c/Users/${USER}/AppData/Local/Programs/Microsoft VS Code/bin":$PATH
 export PATH=~/.npm-global/bin:$PATH
 
+# https://bun.com/docs/installation
+export BUN_INSTALL="$HOME/.bun"
+export PATH="$BUN_INSTALL/bin:$PATH"
+
 # export PATH=$HOME/.emacs.d/bin:$PATH
 #export PATH="$(brew --prefix openssl)/bin:$PATH"
 if which rbenv > /dev/null; then eval "$(rbenv init -)"; fi

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+日本語で回答してください
+
 ## Repository Overview
 
 This is a comprehensive dotfiles repository for development environments, primarily focused on Emacs, shell configuration (Zsh), and development tools. The repository contains personal configuration files for a multi-language development setup including PHP, JavaScript/TypeScript, Ruby, and Python.


### PR DESCRIPTION
## Summary

開発環境の依存関係と設定を更新しました。

- パッケージ依存関係の更新
- Claude Code CLI パスの追加
- Zsh環境の拡張（Azure CLI、Bun、dotenv）
- CLAUDE.md への日本語指示追加

## Changes

- **パッケージ依存関係の更新**（el-get.lock）
  - lsp-bridge, magit, transient, mew のバージョン更新
  - 新規パッケージ追加: eat, vterm, claude-code-ide, pyvenv.el

- **Emacs設定の改善**（init.el）
  - Claude Code CLI パスを exec-path に追加
  - `~/.config/claude/local/` へのパス追加

- **Zsh環境の拡張**
  - Azure CLI 補完サポート追加（.zcompctl）
  - Bun実行環境の設定（.zshrc.mine）
  - dotenv読み込み設定（.zshrc）

- **ドキュメント改善**
  - CLAUDE.md に日本語指示を追加

## Test plan

- [x] Emacs起動時に Claude Code CLI が exec-path に含まれている
- [x] Zsh起動時に Azure CLI 補完が利用可能
- [x] Bun コマンドが利用可能
- [x] パッケージのバージョン更新が正常に適用されている

## Related PRs/Issues

Follows #478 (feat: Claude Code CLI integration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)