### PR TITLE
feat(emacs): ddskkからnskk.elへ日本語入力メソッドを移行

### DIFF
--- a/.emacs.d/el-get.lock
+++ b/.emacs.d/el-get.lock
@@ -1,5 +1,6 @@
 (setq el-get-lock-package-versions
-      '((aio :checksum "58157e51e7eb7a4b954894ee4182564c507a2f01")
+      '((nskk :checksum "4bf42c8e19bc4a9242b8acc8a7445a5df84d1140")
+        (aio :checksum "58157e51e7eb7a4b954894ee4182564c507a2f01")
         (mcp.el :checksum "963b4af6ce743fbb6224f61bb61f05de1c37f511")
         (magit :checksum "3e91100014c58d16413c57cb849f5025e53fb30e")
         (gcmh :checksum "0089f9c3a6d4e9a310d0791cf6fa8f35642ecfd9")

--- a/.emacs.d/init.d/skk-init.el
+++ b/.emacs.d/init.d/skk-init.el
@@ -1,46 +1,5 @@
 ;; -*- emacs-lisp -*-
-;; dot.skk
+;; nskk-init.el - nskk configuration
 ;;
-
-(setq skk-cdb-large-jisyo nil)
-(setq skk-large-jisyo (concat external-directory "ddskk/SKK-JISYO.all.utf8"))
-(setq skk-jisyo-code 'utf-8)
-
-(setq-default skk-kutouten-type 'en)
-(setq-default skk-kuten-touten-alist
-	      '((jp "。" . "、")
-		(en "." . ",")
-		(jp-en "。" . "，")
-		(en-jp "．" . "、")))
-(setq skk-show-tooltip t)
-(setq skk-verbose t)
-(setq skk-show-inline 'vertical)
-(setq skk-use-jisx0201-input-method t)
-(setq skk-share-private-jisyo t)
-(setq skk-save-jisyo-instantly t)
-(setq skk-use-face t)
-(setq skk-use-color-cursor t)
-(setq skk-japanese-message-and-error nil)
-(setq skk-show-annotation nil)
-(setq skk-auto-start-henkan t)
-(setq skk-show-icon t)
-(setq skk-dcomp-activate nil)
-(setq skk-egg-like-newline nil)
-(setq skk-auto-insert-paren t)
-(setq skk-rom-kana-rule-list
-           (append skk-rom-kana-rule-list
-                   '(("@" nil "@"))))
-(defun toggle-skk-kutouten ()
-  "toggle skk-kutoten-type."
-  (interactive)
-  (cond ((eq skk-kutouten-type 'en)
-	 (setq skk-kutouten-type 'jp))
-	((setq skk-kutouten-type 'en)))
-  (message (format "skk-kutoten-type on set to the %s." skk-kutouten-type)))
-
-;;; skk-search-web
-(require 'skk-search-web)
-(add-to-list 'skk-search-prog-list
-	     '(skk-search-web 'skk-google-cgi-api-for-japanese-input)
-	     t)
-;;(add-to-list 'skk-completion-prog-list '(skk-comp-google) t)
+;; This file is kept for reference but nskk configuration
+;; is now in init.el via el-get-bundle nskk settings.

--- a/.emacs.d/init.el
+++ b/.emacs.d/init.el
@@ -150,25 +150,24 @@
   (setq default-process-coding-system '(utf-8 . utf-8))
   (setenv "LANG" "ja_JP.UTF-8"))
 
-(el-get-bundle ddskk
+(el-get-bundle nskk
   :type github
-  :pkgname "skk-dev/ddskk"
-  ;; :info "doc/skk.info"
-  ;; :load-path (".")
-  ;; :autoloads "skk-autoloads"
-  :features ("skk-setup")
-  :build `(("sh" "-c" "echo \"(setq SKK_SET_JISYO t)\" > SKK-CFG")
-           (,el-get-emacs "-batch" "-q" "-no-site-file" "-l" "SKK-MK" "-f" "SKK-MK-compile")
-           (,el-get-emacs "-batch" "-q" "-no-site-file" "-l" "SKK-MK" "-f" "SKK-MK-compile")
-           ;; (,el-get-emacs "-batch" "-q" "-no-site-file" "-l" "SKK-MK" "-f" "SKK-MK-compile-info")
-           ("cp" "skk-setup.el.in" "skk-setup.el")))
+  :pkgname "takeokunn/nskk.el"
+  :branch "main"
+  :autoloads nil)
+;; nskk-azik.el のトップレベルに nskk-converter-register-style の呼び出しがあり、
+;; el-get の autoloads 生成時に .loaddefs.el に取り込まれると
+;; nskk-converter.el 未ロードのため void-function エラーとなる。
+;; :autoloads nil で抑制し、明示的に require する。
+(require 'nskk)
 (setopt
-      skk-server-host nil
-      skk-server-portnum nil
-      skk-user-directory (concat external-directory "ddskk")
-      skk-init-file (concat user-initial-directory "skk-init.el")
-      skk-isearch-start-mode 'latin)
-(setq skk-preload nil)
+      nskk-dict-user-dictionary-file (concat external-directory "nskk/jisyo")
+      nskk-dict-system-dictionary-files
+      (list (concat external-directory "ddskk/SKK-JISYO.all.utf8"))
+      nskk-show-tooltip t
+      nskk-use-color-cursor t
+      nskk-converter-auto-start-henkan t
+      nskk-henkan-show-candidates-nth 5)
 
 ;;; global key-bindings
 (add-hook
@@ -179,11 +178,10 @@
 (global-unset-key (kbd "C-z"))
 (global-unset-key (kbd "C-\\"))
 (global-set-key (kbd "M-g") 'goto-line)
-(global-set-key (kbd "C-j") 'skk-mode)
-(global-set-key (kbd "C-x C-j") 'skk-mode)
+(global-set-key (kbd "C-j") 'nskk-toggle-mode)
+(global-set-key (kbd "C-x C-j") 'nskk-toggle-mode)
 (global-set-key (kbd "C-t") 'other-window)
 (global-set-key (kbd "C-z C-u") 'other-frame)
-(global-set-key (kbd "C-z C-j") 'toggle-skk-kutouten)
 
 (global-set-key (kbd "C-M-g") 'end-of-buffer)
 (global-set-key (kbd "C-M-j") 'next-line)
@@ -1066,8 +1064,7 @@
   (electric-layout-mode t)
   ;; (setq-local electric-layout-rules '((?{ . around)))
   (electric-pair-local-mode t)
-  (with-eval-after-load 'skk
-    (add-to-list 'context-skk-programming-mode 'php-ts-mode)))
+)
 
 (el-get-bundle php-runtime
   :type github
@@ -1204,7 +1201,7 @@
 (gcmh-mode 1)
 (with-eval-after-load 'gcmh
   (setq gcmh-verbose t))
-(define-key minibuffer-local-map (kbd "C-x C-j") 'skk-kakutei)
+(define-key minibuffer-local-map (kbd "C-x C-j") 'nskk-kakutei)
 ;; npm i -g vscode-json-languageserver
 ;; for json format
 ;; see https://qiita.com/saku/items/d97e930ffc9ca39ac976


### PR DESCRIPTION
## Summary
- 日本語入力メソッドをddskk (skk-dev/ddskk) からnskk.el (takeokunn/nskk.el) に移行
- nskk-azik.el の autoloads 互換性問題を `:autoloads nil` + 明示的 `require` で回避
- ddskk固有の設定（skk-init.el, context-skk, toggle-skk-kutouten等）を削除・置換
- キーバインドを `skk-mode` → `nskk-toggle-mode`、`skk-kakutei` → `nskk-kakutei` に更新

## Test plan
- [ ] Emacs起動時にエラーが出ないことを確認
- [ ] `C-j` / `C-x C-j` でnskk-toggle-modeが動作すること
- [ ] 日本語入力・変換が正常に動作すること
- [ ] ミニバッファでの `C-x C-j` (nskk-kakutei) が動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## リリースノート

* **改善**
  * 日本語入力機能の実装を更新しました
  * テキスト入力時のキーバインディングを調整しました

<!-- end of auto-generated comment: release notes by coderabbit.ai -->